### PR TITLE
Rename request param to cred_def_id

### DIFF
--- a/src/email_verification/views.py
+++ b/src/email_verification/views.py
@@ -169,8 +169,7 @@ def webhooks(request, topic):
         request_body = {
             "auto_issue": False,
             "connection_id": message["connection_id"],
-            # FIXME - cred_def_id in 0.4.0+
-            "credential_definition_id": credential_definition_id,
+            "cred_def_id": credential_definition_id,
         }
 
         try:


### PR DESCRIPTION
Renaming request body parameter for compatibility with aca-py 0.4.0+