### PR TITLE
Remove polling handler, update Docker configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,18 +1,27 @@
 # HL Indy Email Verification Service
 
+## Pre-Requisites
+
+- [Docker](https://www.docker.com/products/docker-desktop)
+
+- [s2i](https://github.com/openshift/source-to-image/releases)
+
+- [jq](https://stedolan.github.io/jq)
+
+- [ngrok](https://ngrok.com)
+
+`jq` and `ngrok` are available on package manager systems for different platforms such as [Homebrew](https://brew.sh/) (Mac), [Chocolatey](https://chocolatey.org/) (Windows) and various Linux distribution package managers.
+
 ## Running
 
-Make sure [Docker](https://docker.com) is installed and running.
+Open two shell/terminal sessions:
 
-Install [ngrok[](https://ngrok.com).
+1. From within the [scripts](./scripts) folder execute `./start-ngrok.sh`. This will create a tunnel for the agent.
 
-1. Run `ngrok http 10000`
+2. From within the [docker](./docker) folder:
+    - run `./manage build` to assemble the runtime images for the services
+    - when the build completes, run `./manage up`
 
-1. Copy the `https` url it generates for you (**must be https**)
+_Refer to `manage -h` for additional usage information._
 
-1. Search and replace `https://65cf3bd1.ngrok.io` with the link to the ngrok link you copied (there should be two instances, at lines 13 and 24).
-
-1. In the `docker` directory run;
-   1. `manage build` and `manage up`. _Refer to `manage -h` for additional usage information._
-
-Then visit [http://localhost:8080](http://localhost:8080) to see the app running and visit [http://localhost:8050](http://localhost:8050) to see any outbound mail the app is sending (it won't actually send any email message in the development environment.)
+Once services are started, visit [http://localhost:8080](http://localhost:8080) to see the app running and visit [http://localhost:8050](http://localhost:8050) to see any outbound mail the app is sending (it won't actually send any email message in the development environment.)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,22 +1,38 @@
 version: "3"
 services:
   email-verifier-agent:
+    image: bcgovimages/aries-cloudagent:py36-1.14-1_0.4.5
     environment:
       ADMIN_PORT: 5000
       AGENT_PORT: 10000
-      INDY_SEED: "00000000000000000000000000000001"
-      SITE_URL: https://132faea5.ngrok.io
+      INDY_SEED: ${AGENT_WALLET_SEED}
+      SITE_URL: ${SITE_URL}
       WEBHOOK_URL: http://email-verifier-service:8080/webhooks
       AGENT_LABEL: BC Email Verifier
-    build:
-      context: ..
-      dockerfile: ./docker/email-verification-agent/Dockerfile
     ports:
       - "5000:5000"
       - "10000:10000"
     volumes:
       - aca-py:/home/indy/.indy_client/wallet
-    command: start -it http 0.0.0.0 10000 -ot http --admin 0.0.0.0 5000 -e https://132faea5.ngrok.io --wallet-type indy --seed 00000000000000000000000000000001 --genesis-url http://138.197.138.255/genesis --label "BC Email Verifier" --auto-accept-invites --auto-accept-requests --admin-insecure-mode --log-level info
+    entrypoint: /bin/bash
+    command: [
+        "-c",
+        "curl -d '{\"seed\":\"${AGENT_WALLET_SEED}\", \"role\":\"TRUST_ANCHOR\", \"alias\":\"BC Email Verifier (Docker)\"}' -X POST http://test.bcovrin.vonx.io/register; \
+        sleep 5; \
+        aca-py start \
+        -it http '0.0.0.0' 10000 \
+        -ot http \
+        --admin '0.0.0.0' 5000 \
+        -e $SITE_URL \
+        --wallet-type indy \
+        --seed $AGENT_WALLET_SEED \
+        --genesis-url http://test.bcovrin.vonx.io/genesis \
+        --label 'BC Email Verifier' \
+        --auto-accept-invites \
+        --auto-accept-requests \
+        --admin-insecure-mode \
+        --log-level info",
+      ]
 
   email-verifier-service:
     restart: always

--- a/docker/manage
+++ b/docker/manage
@@ -3,13 +3,95 @@ export MSYS_NO_PATHCONV=1
 export DOCKERHOST=${APPLICATION_URL-$(docker run --rm --net=host eclipse/che-ip)}
 set -e
 
-S2I_EXE=s2i
-if [ -z $(type -P "$S2I_EXE") ]; then
-  echo -e "The ${S2I_EXE} executable is needed and not on your path."
-  echo -e "It can be downloaded from here: https://github.com/openshift/source-to-image"
-  echo -e "Make sure you place it in a directory on your path."
-  exit 1
-fi
+function echoError (){
+  _msg=${1}
+  _red='\e[31m'
+  _nc='\e[0m' # No Color
+  echo -e "${_red}${_msg}${_nc}"
+}
+
+function echoWarning (){
+  _msg=${1}
+  _yellow='\e[33m'
+  _nc='\e[0m' # No Color
+  echo -e "${_yellow}${_msg}${_nc}"
+}
+
+function isInstalled () {
+  rtnVal=$(type "$1" >/dev/null 2>&1)
+  rtnCd=$?
+  if [ ${rtnCd} -ne 0 ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+function isS2iInstalled () {
+  S2I_EXE=s2i
+  if ! isInstalled ${S2I_EXE}; then
+    echoError "The ${S2I_EXE} executable is needed and not on your path."
+    echoError "It can be downloaded from here: https://github.com/openshift/source-to-image/releases"
+    echoError "Make sure you extract the binary and place it in a directory on your path."
+    exit 1
+  fi
+}
+
+function isJQInstalled () {
+  JQ_EXE=jq
+  if ! isInstalled ${JQ_EXE}; then
+    echoError "The ${JQ_EXE} executable is required and was not found on your path."
+    echoError "Installation instructions can be found here: https://stedolan.github.io/jq/download"
+    echoError "Alternatively, a package manager such as Chocolatey (Windows) or Brew (Mac) can be used to install this dependecy."
+    exit 1
+  fi
+}
+
+function isCurlInstalled () {
+  CURL_EXE=curl
+  if ! isInstalled ${CURL_EXE}; then
+    echoError "The ${CURL_EXE} executable is required and was not found on your path."
+    echoError "If your shell of choice doesn't come with curl preinstalled, try installing it using either [Homebrew](https://brew.sh/) (MAC) or [Chocolatey](https://chocolatey.org/) (Windows)."
+    exit 1
+  fi
+}
+
+function isNgrokInstalled () {
+  NGROK_EXE=ngrok
+  if ! isInstalled ${NGROK_EXE}; then
+    echoError "The ${NGROK_EXE} executable is needed and not on your path."
+    echoError "It can be downloaded from here: https://ngrok.com/download"
+    echoError "Alternatively, a package manager such as Chocolatey (Windows) or Brew (Mac) can be used to install this dependecy."
+    exit 1
+  fi
+}
+
+function checkNgrokTunnelActive () {
+  if [ -z "${SITE_URL}" ]; then
+    echoError "It appears that ngrok tunneling is not enabled."
+    echoError "Please open another shell in the scripts folder and execute start-ngrok.sh before trying again."
+    exit 1
+  fi
+}
+
+function generateKey(){
+  (
+    _length=${1:-48}
+    # Format can be `-base64` or `-hex`
+    _format=${2:--base64}
+
+    echo $(openssl rand ${_format} ${_length})
+  )
+}
+
+function generateSeed(){
+  (
+    _prefix=${1}
+    _seed=$(echo "${_prefix}$(generateKey 32)" | fold -w 32 | head -n 1 )
+    _seed=$(echo -n "${_seed}")
+    echo ${_seed}
+  )
+}
 
 SCRIPT_HOME="$(cd "$(dirname "$0")" && pwd)"
 
@@ -146,6 +228,17 @@ shift || COMMAND=usage
 
 case "${COMMAND}" in
 start|up)
+  isJQInstalled
+  isCurlInstalled
+  isNgrokInstalled
+  
+  export SITE_URL=$(${CURL_EXE} http://localhost:4040/api/tunnels | ${JQ_EXE} --raw-output '.tunnels | map(select(.name | contains("(http)"))) | .[0] | .public_url')
+  checkNgrokTunnelActive
+
+  if [ -z "${AGENT_WALLET_SEED}" ]; then
+    export AGENT_WALLET_SEED=$(generateSeed indy-evs)
+  fi
+
   _startupParams=$(getStartupParams $@)
   configureEnvironment $@
   docker-compose up -d ${_startupParams}
@@ -160,11 +253,13 @@ stop)
   docker-compose stop 
   ;;
 rm|down)
+  unset AGENT_WALLET_SEED 
   configureEnvironment
   docker-compose down
   deleteVolumes
   ;;
 build)
+  isS2iInstalled
   _startupParams=$(getStartupParams $@)
   configureEnvironment $@
   case "$@" in

--- a/scripts/start-ngrok.sh
+++ b/scripts/start-ngrok.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$OSTYPE" == "msys" ]; then
+  NGROK="winpty ngrok"
+else
+  NGROK="ngrok"
+fi
+
+$NGROK http 10000 --log=stdout

--- a/src/email_verification/templates/in_progress.html
+++ b/src/email_verification/templates/in_progress.html
@@ -30,7 +30,7 @@
     <script>
       (async () => {
         var state = '{{state}}'
-        setInterval(async function(){
+        var interval = setInterval(async function(){
           try {
             console.log("getting state...")
             const response = await fetch('/state/' + '{{connection_id}}');
@@ -58,6 +58,8 @@
               
               el = document.querySelector('#email-placeholder');
               el.textContent = state["email"]
+
+              clearInterval(interval)
             }
             
           } catch (e) {


### PR DESCRIPTION
We were apparently not clearing the polling handler once finished with the credential issuance flow: while this is not an issue per se in most cases, if the browser window is left open it will keep refreshing even once the flow is completed (I could see attempts in the logs).

I also updated the Docker configuration as the agent was not starting locally, and to include additional automation for ngrok.