### PR TITLE
Add email-verification demo app deployment configurations

### DIFF
--- a/openshift/settings.demo.sh
+++ b/openshift/settings.demo.sh
@@ -1,3 +1,4 @@
+# Description: Email Verification OIDC Demo App
 export PROJECT_NAMESPACE="devex-von-image"
 export GIT_URI="https://github.com/bcgov/vc-authn-oidc.git"
 export GIT_REF="master"

--- a/openshift/settings.demo.sh
+++ b/openshift/settings.demo.sh
@@ -1,0 +1,19 @@
+export PROJECT_NAMESPACE="devex-von-image"
+export GIT_URI="https://github.com/bcgov/vc-authn-oidc.git"
+export GIT_REF="master"
+
+export SKIP_PIPELINE_PROCESSING=1
+
+export skip_git_overrides="visual-verifier-build.json"
+
+export ignore_templates="indy-email-verification email-verification-agent-build email-verification-agent-deploy email-verification-service-build email-verification-service-deploy postgresql-build postgresql-deploy"
+
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Override environments, since there is only one AT THE MOMENT:
+# devex-von-image-tools
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+export TOOLS="devex-von-image-tools"
+export DEPLOYMENT_ENV_NAME="tools"
+export DEV="tools"
+export TEST="tools"
+export PROD="tools"

--- a/openshift/templates/visual-verifier/visual-verifier-build.demo.param
+++ b/openshift/templates/visual-verifier/visual-verifier-build.demo.param
@@ -1,0 +1,22 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# Template File: ../openshift/templates/visual-verifier/visual-verifier-build.json
+#=========================================================
+NAME=email-verification-demo
+APP_NAME=email-verification-demo
+APP_GROUP=email-verification-demo
+OUTPUT_IMAGE_TAG=latest
+SOURCE_IMAGE_NAME=registry.fedoraproject.org/f32/python3
+SOURCE_IMAGE_TAG=latest
+SOURCE_IMAGE_KIND=DockerImage
+SOURCE_CONTEXT_DIR=src
+GIT_REPO_URL=https://github.com/bcgov/vc-visual-verifier.git
+GIT_REF=master
+PIP_INDEX_URL=
+UPGRADE_PIP_TO_LATEST=true
+PIP_NO_CACHE_DIR=
+CPU_LIMIT=1
+MEMORY_LIMIT=1Gi
+CPU_REQUEST=250m
+MEMORY_REQUEST=250m

--- a/openshift/templates/visual-verifier/visual-verifier-build.json
+++ b/openshift/templates/visual-verifier/visual-verifier-build.json
@@ -1,0 +1,210 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "annotations": {
+      "description": "Build template for a django server.",
+      "tags": "django",
+      "iconClass": "icon-python"
+    },
+    "name": "${NAME}-build-template"
+  },
+  "objects": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "labels": {
+          "name": "${NAME}",
+          "app": "${APP_NAME}",
+          "app-group": "${APP_GROUP}"
+        }
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "labels": {
+          "name": "${NAME}",
+          "app": "${APP_NAME}",
+          "app-group": "${APP_GROUP}"
+        }
+      },
+      "spec": {
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "${GIT_REPO_URL}",
+            "ref": "${GIT_REF}"
+          },
+          "contextDir": "${SOURCE_CONTEXT_DIR}"
+        },
+        "strategy": {
+          "type": "Source",
+          "sourceStrategy": {
+            "from": {
+              "kind": "${SOURCE_IMAGE_KIND}",
+              "name": "${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}"
+            },
+            "env": [
+              {
+                "name": "PIP_INDEX_URL",
+                "value": "${PIP_INDEX_URL}"
+              },
+              {
+                "name": "UPGRADE_PIP_TO_LATEST",
+                "value": "${UPGRADE_PIP_TO_LATEST}"
+              },
+              {
+                "name": "PIP_NO_CACHE_DIR",
+                "value": "${PIP_NO_CACHE_DIR}"
+              }
+            ]
+          }
+        },
+        "output": {
+          "to": {
+            "kind": "ImageStreamTag",
+            "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
+          }
+        },
+        "resources": {
+          "requests": {
+            "cpu": "${CPU_REQUEST}",
+            "memory": "${MEMORY_REQUEST}"
+          },
+          "limits": {
+            "cpu": "${CPU_LIMIT}",
+            "memory": "${MEMORY_LIMIT}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ]
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the objects defined in this template.  You should keep this as default unless your know what your doing.",
+      "required": true,
+      "value": "visual-verifier"
+    },
+    {
+      "name": "APP_NAME",
+      "displayName": "App Name",
+      "description": "Used to group components together in the OpenShift console.",
+      "required": true,
+      "value": "issuer-kit"
+    },
+    {
+      "name": "APP_GROUP",
+      "displayName": "App Group",
+      "description": "The name assigned to all of the deployments in this project.",
+      "required": true,
+      "value": "issuer-kit-runtime"
+    },
+    {
+      "name": "OUTPUT_IMAGE_TAG",
+      "displayName": "Output Image Tag",
+      "description": "The tag given to the built image.",
+      "required": true,
+      "value": "latest"
+    },
+    {
+      "name": "SOURCE_IMAGE_NAME",
+      "displayName": "Source Image Name",
+      "required": true,
+      "description": "The name of the source image.",
+      "value": "registry.fedoraproject.org/f32/python3"
+    },
+    {
+      "name": "SOURCE_IMAGE_TAG",
+      "displayName": "Source Image Tag",
+      "required": true,
+      "description": "The tag of the source image.",
+      "value": "latest"
+    },
+    {
+      "name": "SOURCE_IMAGE_KIND",
+      "displayName": "Source Image Kind",
+      "required": true,
+      "description": "The 'kind' (type) of the  source image; typically ImageStreamTag, or DockerImage.",
+      "value": "DockerImage"
+    },
+    {
+      "name": "SOURCE_CONTEXT_DIR",
+      "displayName": "Source Context Directory",
+      "description": "The source context directory.",
+      "required": true,
+      "value": "src"
+    },
+    {
+      "name": "GIT_REPO_URL",
+      "displayName": "Git Repo URL",
+      "description": "The URL to your GIT repo, don't use the this default unless your just experimenting.",
+      "required": true,
+      "value": "https://github.com/bcgov/vc-visual-verifier.git"
+    },
+    {
+      "name": "GIT_REF",
+      "displayName": "Git Reference",
+      "description": "The git reference or branch.",
+      "required": true,
+      "value": "master"
+    },
+    {
+      "name": "PIP_INDEX_URL",
+      "displayName": "Custom PyPi Index URL",
+      "description": "The custom PyPi index URL",
+      "value": ""
+    },
+    {
+      "name": "UPGRADE_PIP_TO_LATEST",
+      "displayName": "Upgrade Pip To Latest",
+      "description": "Upgrade Pip To Latest",
+      "value": "true"
+    },
+    {
+      "name": "PIP_NO_CACHE_DIR",
+      "displayName": "Pip No Cache Dir",
+      "description": "Pip No Cache Dir",
+      "value": ""
+    },
+    {
+      "name": "CPU_LIMIT",
+      "displayName": "Resources CPU Limit",
+      "description": "The resources CPU limit (in cores) for this build.",
+      "required": true,
+      "value": "1"
+    },
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Resources Memory Limit",
+      "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
+      "required": true,
+      "value": "1Gi"
+    },
+    {
+      "name": "CPU_REQUEST",
+      "displayName": "Resources CPU Request",
+      "description": "The resources CPU request (in cores) for this build.",
+      "required": true,
+      "value": "250m"
+    },
+    {
+      "name": "MEMORY_REQUEST",
+      "displayName": "Resources Memory Request",
+      "description": "The resources Memory request (in Mi, Gi, etc) for this build.",
+      "required": true,
+      "value": "250m"
+    }
+  ]
+}

--- a/openshift/templates/visual-verifier/visual-verifier-deploy.demo.param
+++ b/openshift/templates/visual-verifier/visual-verifier-deploy.demo.param
@@ -1,0 +1,29 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# Template File: ../openshift/templates/visual-verifier/visual-verifier-deploy.json
+#=========================================================
+NAME=email-verification-demo
+APP_NAME=email-verification-demo
+APP_GROUP=email-verification-demo
+SUFFIX=
+ROLE=email-verification-demo
+APPLICATION_DOMAIN=verified-email-authentication.pathfinder.gov.bc.ca
+IMAGE_NAMESPACE=devex-von-image-tools
+TAG_NAME=latest
+APP_FILE=
+APP_CONFIG=
+APP_MODULE=
+# DJANGO_SECRET_KEY=[\w]{50}
+DJANGO_DEBUG=False
+VERIFIER_NAME=Verified Email Authentication
+OIDC_RP_PROVIDER_ENDPOINT=
+OIDC_RP_CLIENT_ID=
+OIDC_RP_CLIENT_SECRET=
+OIDC_RP_SCOPES=openid profile vc_authn
+VC_AUTHN_PRES_REQ_CONF_ID=
+OIDC_CLAIMS_REQUIRED=
+CPU_REQUEST=10m
+CPU_LIMIT=300m
+MEMORY_REQUEST=10Mi
+MEMORY_LIMIT=256Mi

--- a/openshift/templates/visual-verifier/visual-verifier-deploy.demo.tools.param
+++ b/openshift/templates/visual-verifier/visual-verifier-deploy.demo.tools.param
@@ -1,0 +1,29 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: .
+# Template File: ../openshift/templates/visual-verifier/visual-verifier-deploy.json
+#=========================================================
+# NAME=email-verification-demo
+# APP_NAME=email-verification-demo
+# APP_GROUP=email-verification-demo
+# SUFFIX=
+ROLE=email-verification-demo
+APPLICATION_DOMAIN=verified-email-authentication.pathfinder.gov.bc.ca
+# IMAGE_NAMESPACE=devex-von-image-tools
+TAG_NAME=latest
+# APP_FILE=
+# APP_CONFIG=
+# APP_MODULE=
+# #DJANGO_SECRET_KEY=[\w]{50}
+# DJANGO_DEBUG=False
+# VERIFIER_NAME=VC Visual Verifier
+# OIDC_RP_PROVIDER_ENDPOINT=
+# OIDC_RP_CLIENT_ID=
+# OIDC_RP_CLIENT_SECRET=
+# OIDC_RP_SCOPES=openid profile vc_authn
+# VC_AUTHN_PRES_REQ_CONF_ID=
+# OIDC_CLAIMS_REQUIRED=
+# CPU_REQUEST=10m
+# CPU_LIMIT=300m
+# MEMORY_REQUEST=10Mi
+# MEMORY_LIMIT=256Mi

--- a/openshift/templates/visual-verifier/visual-verifier-deploy.json
+++ b/openshift/templates/visual-verifier/visual-verifier-deploy.json
@@ -1,0 +1,443 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "${NAME}${SUFFIX}-deployment-template",
+    "annotations": {
+      "description": "Deployment template for a django server connected to a PostGreSQL database.",
+      "tags": "django",
+      "iconClass": "icon-python"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Secret",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}${SUFFIX}",
+        "labels": {
+          "app": "${APP_NAME}${SUFFIX}",
+          "name": "${NAME}${SUFFIX}",
+          "app-group": "${APP_GROUP}",
+          "role": "${ROLE}",
+          "env": "${TAG_NAME}"
+        }
+      },
+      "stringData": {
+        "oidc-rp-provider-endpoint": "${OIDC_RP_PROVIDER_ENDPOINT}",
+        "oidc-rp-client-id": "${OIDC_RP_CLIENT_ID}",
+        "oidc-rp-client-secret": "${OIDC_RP_CLIENT_SECRET}",
+        "oidc-rp-scopes": "${OIDC_RP_SCOPES}",
+        "vc-authn-pres-req-conf-id": "${VC_AUTHN_PRES_REQ_CONF_ID}",
+        "oidc-claims-required": "${OIDC_CLAIMS_REQUIRED}"
+      },
+      "type": "Opaque"
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}${SUFFIX}",
+        "labels": {
+          "name": "${NAME}${SUFFIX}",
+          "app": "${APP_NAME}${SUFFIX}",
+          "app-group": "${APP_GROUP}",
+          "role": "${ROLE}",
+          "env": "${TAG_NAME}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "8080-tcp",
+            "port": 8080,
+            "protocol": "TCP",
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "name": "${NAME}${SUFFIX}"
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Route",
+      "metadata": {
+        "labels": {
+          "app": "${APP_NAME}${SUFFIX}",
+          "name": "${NAME}${SUFFIX}",
+          "app-group": "${APP_GROUP}",
+          "role": "${ROLE}",
+          "env": "${TAG_NAME}"
+        },
+        "name": "${NAME}${SUFFIX}"
+      },
+      "spec": {
+        "host": "${APPLICATION_DOMAIN}",
+        "port": {
+          "targetPort": "8080-tcp"
+        },
+        "tls": {
+          "insecureEdgeTerminationPolicy": "Redirect",
+          "termination": "edge"
+        },
+        "to": {
+          "kind": "Service",
+          "name": "${NAME}${SUFFIX}",
+          "weight": 100
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}${SUFFIX}",
+        "annotations": {
+          "description": "Defines how to deploy the application server"
+        },
+        "labels": {
+          "name": "${NAME}${SUFFIX}",
+          "app": "${APP_NAME}${SUFFIX}",
+          "app-group": "${APP_GROUP}",
+          "role": "${ROLE}",
+          "env": "${TAG_NAME}"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Rolling"
+        },
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "${NAME}${SUFFIX}"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "namespace": "${IMAGE_NAMESPACE}",
+                "name": "${NAME}:${TAG_NAME}"
+              }
+            }
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "${NAME}${SUFFIX}"
+        },
+        "template": {
+          "metadata": {
+            "name": "${NAME}${SUFFIX}",
+            "labels": {
+              "name": "${NAME}${SUFFIX}",
+              "app": "${APP_NAME}${SUFFIX}",
+              "app-group": "${APP_GROUP}",
+              "role": "${ROLE}",
+              "env": "${TAG_NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "${NAME}${SUFFIX}",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "readinessProbe": {
+                  "failureThreshold": 5,
+                  "periodSeconds": 30,
+                  "initialDelaySeconds": 3,
+                  "timeoutSeconds": 40,
+                  "httpGet": {
+                    "path": "/",
+                    "port": 8080
+                  }
+                },
+                "livenessProbe": {
+                  "failureThreshold": 5,
+                  "periodSeconds": 60,
+                  "initialDelaySeconds": 30,
+                  "timeoutSeconds": 40,
+                  "httpGet": {
+                    "path": "/",
+                    "port": 8080
+                  }
+                },
+                "env": [
+                  {
+                    "name": "APP_FILE",
+                    "value": "${APP_FILE}"
+                  },
+                  {
+                    "name": "APP_CONFIG",
+                    "value": "${APP_CONFIG}"
+                  },
+                  {
+                    "name": "APP_MODULE",
+                    "value": "${APP_MODULE}"
+                  },
+                  {
+                    "name": "DJANGO_SECRET_KEY",
+                    "value": "${DJANGO_SECRET_KEY}"
+                  },
+                  {
+                    "name": "DJANGO_DEBUG",
+                    "value": "${DJANGO_DEBUG}"
+                  },
+                  {
+                    "name": "VERIFIER_NAME",
+                    "value": "${VERIFIER_NAME}"
+                  },
+                  {
+                    "name": "OIDC_RP_PROVIDER_ENDPOINT",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}${SUFFIX}",
+                        "key": "oidc-rp-provider-endpoint"
+                      }
+                    }
+                  },
+                  {
+                    "name": "OIDC_RP_CLIENT_ID",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}${SUFFIX}",
+                        "key": "oidc-rp-client-id"
+                      }
+                    }
+                  },
+                  {
+                    "name": "OIDC_RP_CLIENT_SECRET",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}${SUFFIX}",
+                        "key": "oidc-rp-client-secret"
+                      }
+                    }
+                  },
+                  {
+                    "name": "OIDC_RP_SCOPES",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}${SUFFIX}",
+                        "key": "oidc-rp-scopes"
+                      }
+                    }
+                  },
+                  {
+                    "name": "VC_AUTHN_PRES_REQ_CONF_ID",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}${SUFFIX}",
+                        "key": "vc-authn-pres-req-conf-id"
+                      }
+                    }
+                  },
+                  {
+                    "name": "OIDC_CLAIMS_REQUIRED",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}${SUFFIX}",
+                        "key": "oidc-claims-required"
+                      }
+                    }
+                  }
+                ],
+                "resources": {
+                  "requests": {
+                    "cpu": "${CPU_REQUEST}",
+                    "memory": "${MEMORY_REQUEST}"
+                  },
+                  "limits": {
+                    "cpu": "${CPU_LIMIT}",
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the OpenShift resources associated to the server instance.",
+      "required": true,
+      "value": "visual-verifier"
+    },
+    {
+      "name": "APP_NAME",
+      "displayName": "App Name",
+      "description": "Used to group components together in the OpenShift console.",
+      "required": true,
+      "value": "visual-verifier"
+    },
+    {
+      "name": "APP_GROUP",
+      "displayName": "App Group",
+      "description": "The name assigned to all of the deployments in this project.",
+      "required": true,
+      "value": "visual-verifier"
+    },
+    {
+      "name": "SUFFIX",
+      "displayName": "Suffix",
+      "description": "A name suffix used for all objects",
+      "required": false,
+      "value": ""
+    },
+    {
+      "name": "ROLE",
+      "displayName": "Role",
+      "description": "The role of this service within the application - used for Network Policies",
+      "required": true,
+      "value": "visual-verifier"
+    },
+    {
+      "description": "The exposed hostname that will route to the service, e.g., myappname.pathfinder.gov.bc.ca, if left blank a value will be defaulted.",
+      "displayName": "Application Hostname",
+      "name": "APPLICATION_DOMAIN",
+      "value": "visual-verifier-dev.pathfinder.gov.bc.ca"
+    },
+    {
+      "name": "IMAGE_NAMESPACE",
+      "displayName": "Image Namespace",
+      "required": true,
+      "description": "The namespace of the OpenShift project containing the imagestream for the application.",
+      "value": "bztwou-tools"
+    },
+    {
+      "name": "TAG_NAME",
+      "displayName": "Environment TAG name",
+      "description": "The TAG name for this environment, e.g., dev, test, prod",
+      "value": "dev",
+      "required": true
+    },
+    {
+      "name": "APP_FILE",
+      "displayName": "Application File",
+      "description": "Used to run the application from a Python script. This should be a path to a Python file (defaults to app.py unless set to null) that will be passed to the Python interpreter to start the application (optional).",
+      "required": false,
+      "value": ""
+    },
+    {
+      "name": "APP_CONFIG",
+      "displayName": "Application Configuration File Path",
+      "description": "Relative path to Gunicorn configuration file (optional).",
+      "required": false,
+      "value": ""
+    },
+    {
+      "name": "APP_MODULE",
+      "displayName": "Application Module",
+      "description": "The python module for application startup.",
+      "required": false,
+      "value": ""
+    },
+    {
+      "name": "DJANGO_SECRET_KEY",
+      "displayName": "Django Secret Key",
+      "description": "Set this to a long random string.",
+      "generate": "expression",
+      "from": "[\\w]{50}"
+    },
+    {
+      "name": "DJANGO_DEBUG",
+      "displayName": "Django Debug",
+      "description": "If Django is in debug mode",
+      "required": true,
+      "value": "False"
+    },
+    {
+      "name": "VERIFIER_NAME",
+      "displayName": "Verifier Name",
+      "description": "Verifier Name",
+      "required": true,
+      "value": "VC Visual Verifier"
+    },
+    {
+      "name": "OIDC_RP_PROVIDER_ENDPOINT",
+      "displayName": "OIDC RP Provider Endpoint",
+      "description": "OIDC RP Provider Endpoint",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "OIDC_RP_CLIENT_ID",
+      "displayName": "OIDC RP Client Id",
+      "description": "OIDC RP Client Id",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "OIDC_RP_CLIENT_SECRET",
+      "displayName": "OIDC RP Client Secret",
+      "description": "OIDC RP Client Secret",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "OIDC_RP_SCOPES",
+      "displayName": "OIDC RP Scopes",
+      "description": "OIDC RP Scopes",
+      "required": false,
+      "value": "openid profile vc_authn"
+    },
+    {
+      "name": "VC_AUTHN_PRES_REQ_CONF_ID",
+      "displayName": "VC Authentication Presentation Request Configuration Id",
+      "description": "VC Authentication Presentation Request Configuration Id",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "OIDC_CLAIMS_REQUIRED",
+      "displayName": "OIDC Claims Required",
+      "description": "OIDC Claims Required",
+      "required": true,
+      "value": ""
+    },
+    {
+      "name": "CPU_REQUEST",
+      "displayName": "Resources CPU Request",
+      "description": "The resources CPU request (in cores) for this build.",
+      "required": true,
+      "value": "10m"
+    },
+    {
+      "name": "CPU_LIMIT",
+      "displayName": "Resources CPU Limit",
+      "description": "The resources CPU limit (in cores) for this build.",
+      "required": true,
+      "value": "300m"
+    },
+    {
+      "name": "MEMORY_REQUEST",
+      "displayName": "Resources Memory Request",
+      "description": "The resources Memory request (in Mi, Gi, etc) for this build.",
+      "required": true,
+      "value": "10Mi"
+    },
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Resources Memory Limit",
+      "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
+      "required": true,
+      "value": "256Mi"
+    }
+  ]
+}

--- a/openshift/templates/visual-verifier/visual-verifier-deploy.overrides.sh
+++ b/openshift/templates/visual-verifier/visual-verifier-deploy.overrides.sh
@@ -1,0 +1,29 @@
+_includeFile=$(type -p overrides.inc)
+if [ ! -z ${_includeFile} ]; then
+  . ${_includeFile}
+else
+  _red='\033[0;31m'; _yellow='\033[1;33m'; _nc='\033[0m'; echo -e \\n"${_red}overrides.inc could not be found on the path.${_nc}\n${_yellow}Please ensure the openshift-developer-tools are installed on and registered on your path.${_nc}\n${_yellow}https://github.com/BCDevOps/openshift-developer-tools${_nc}"; exit 1;
+fi
+
+# ================================================================================================================
+# Special deployment parameters needed for injecting a user supplied settings into the deployment configuration
+# ----------------------------------------------------------------------------------------------------------------
+if createOperation; then
+  # Ask the user to supply the sensitive parameters ...
+  readParameter "OIDC_RP_PROVIDER_ENDPOINT - Please provide the URL for your VC OIDC Identty Provider.  The value may not be blank:" OIDC_RP_PROVIDER_ENDPOINT "" "false"
+  readParameter "OIDC_RP_CLIENT_ID - Please provide your OIDC Identty Provider client id. This value must match the client id in your Identity Provider.  The value may not be blank:" OIDC_RP_CLIENT_ID "" "false"
+  readParameter "OIDC_RP_CLIENT_SECRET - Please provide your OIDC Identty Provider client secret. This value must match the client secret in your Identity Provider.  If left blank, a 32 character long base64 encoded value will be randomly generated using openssl:" OIDC_RP_CLIENT_SECRET $(generateKey 32) "false"
+  readParameter "VC_AUTHN_PRES_REQ_CONF_ID - Please provide the presentation request configuration id to be used when authenticating.  The value may not be blank:" VC_AUTHN_PRES_REQ_CONF_ID "" "false"
+  readParameter "OIDC_CLAIMS_REQUIRED - Please provide the list of claims to be checked by the verifier as a comma-separated list of values.    The value may not be blank:" OIDC_CLAIMS_REQUIRED "" "false"
+else
+  # Secrets are removed from the configurations during update operations ...
+  printStatusMsg "Update operation detected ...\nSkipping the prompts for OIDC_RP_PROVIDER_ENDPOINT, OIDC_RP_CLIENT_ID, OIDC_RP_CLIENT_SECRET, VC_AUTHN_PRES_REQ_CONF_ID, and OIDC_CLAIMS_REQUIRED secrets ... \n"
+  writeParameter "OIDC_RP_PROVIDER_ENDPOINT" "prompt_skipped" "false"
+  writeParameter "OIDC_RP_CLIENT_ID" "prompt_skipped" "false"
+  writeParameter "OIDC_RP_CLIENT_SECRET" "prompt_skipped" "false"
+  writeParameter "VC_AUTHN_PRES_REQ_CONF_ID" "prompt_skipped" "false"
+  writeParameter "OIDC_CLAIMS_REQUIRED" "prompt_skipped" "false"
+fi
+
+SPECIALDEPLOYPARMS="--param-file=${_overrideParamFile}"
+echo ${SPECIALDEPLOYPARMS}

--- a/proof-configurations/verified-email.json
+++ b/proof-configurations/verified-email.json
@@ -1,0 +1,22 @@
+{
+  "id": "verified-email",
+  "subject_identifier": "email",
+  "configuration": {
+    "name": "verified-email",
+    "version": "1.0",
+    "requested_attributes": [
+      {
+        "name": "email",
+        "label": "Verified Email",
+        "restrictions": [
+          {
+            "schema_name": "verified-email",
+            "schema_version": "1.2.2",
+            "issuer_did": "MTYqmTBoLT7KLP5RNfgK3b"
+          }
+        ]
+      }
+    ],
+    "requested_predicates": []
+  }
+}


### PR DESCRIPTION
App is tested and deployed in the same namespace hosting the `email-verification-service` app.

Since this is a standalone service with a single deployment, to keep things simple I would target `latest` in the imagestream and just add a webhook directly into the build rather than having a full pipeline.

Thoughts?