### PR TITLE
updated dependancies to prevent dependabot alerts

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
   email-verifier-postgres:
     restart: always
-    image: postgres:latest
+    image: postgres:10
     volumes:
       - /var/lib/postgresql
     ports:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,8 +1,8 @@
 certifi>=2019.3.9
 chardet==3.0.4
-Django>=2.2.4,<3
+Django>=3.1.13
 idna==2.8
-Pillow>=6.2.2,<7
+Pillow>=8.3.2
 psycopg2==2.8.2
 pytz==2019.1
 qrcode==6.1
@@ -13,4 +13,4 @@ urllib3==1.26.5
 
 # Web Server
 gunicorn>=19.7.1,<20
-whitenoise>=3.3.1,<4
+whitenoise>=5.0.1


### PR DESCRIPTION
- updated django to `Django>=3.1.13`, consequently needed to update whitenoise to `whitenoise>=5.0.1`
- updated pillow to `Pillow>=8.3.2`
- downgraded postgres from latest to `postgres:10`. Postgres 10 is consistent with what we use in openshift, and later versions of postgres trigger the following error when submitting an email verification request: `SCRAM authentication requires libpq version 10 or above`  
  

resolves #72 